### PR TITLE
fixing uppercase character in startswith call

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -60,7 +60,7 @@ def is_config_enabled(param):
 def ban(ip):
     # ip check routine to see if its a valid IP address
     if not ip.startswith("#"):
-     if not ip.startswitH("0.0"):
+     if not ip.startswith("0.0"):
       if is_valid_ipv4(ip.strip()):
         # if we are running nix variant then trigger ban through iptables
         if is_posix():

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -56,7 +56,7 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                     self.request.close()
 
                     # if it isn't whitelisted and we are set to ban
-                    ban(self.client_address[0])
+                    ban(ip)
 
         except Exception, e:
             print "[!] Error detected. Printing: " + str(e)


### PR DESCRIPTION
Someone introduced an uppercase character in a startswith call in the ban function;  it fails silently and isn't caught by any exceptions, so right now the ban function is plain broken and doesn't alert to the failure
Also changed honeypot ban call to use 'ip' variable for ease of reading through function