### PR TITLE
Update core.py

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -437,14 +437,13 @@ def syslog(message):
     if type == "file":
         if not os.path.isdir("/var/artillery/logs"):
             os.makedirs("/var/artillery/logs")
-            if not os.path.isfile("/var/artillery/logs/alerts.log"):
-                filewrite = open("/var/artillery/logs/alerts.log", "w")
-                filewrite.write("***** Artillery Alerts Log *****\n")
-                filewrite.close()
-
-            filewrite = open("/var/artillery/logs/alerts.log", "a")
-            filewrite.write(message + "\n")
+        if not os.path.isfile("/var/artillery/logs/alerts.log"):
+            filewrite = open("/var/artillery/logs/alerts.log", "w")
+            filewrite.write("***** Artillery Alerts Log *****\n")
             filewrite.close()
+        filewrite = open("/var/artillery/logs/alerts.log", "a")
+        filewrite.write(message + "\n")
+        filewrite.close()
 
 def write_log(alert):
     if is_posix():


### PR DESCRIPTION
Fixed a spacing issue committed in d37ded4. The spacing made it so that when syslog was set to "file" nothing was written to the log unless the folder didn't exist previously and the file was missing.

This fix replicated functionality before d37ded4.
