### PR TITLE
Use os.makedirs instead of os.mkdirs

### DIFF
--- a/artillery.py
+++ b/artillery.py
@@ -67,7 +67,7 @@ if is_posix():
         sys.exit(1)
     else:
         if not os.path.isdir("/var/artillery/database/"):
-            os.mkdirs("/var/artillery/database/")
+            os.makedirs("/var/artillery/database/")
         if not os.path.isfile("/var/artillery/database/temp.database"):
             filewrite = open("/var/artillery/database/temp.database", "w")
             filewrite.write("")


### PR DESCRIPTION
The proper way to recursively create directories is to use `os.makedirs()`.

`os.mkdirs` does not exist (thanks for that solid consistent naming convention, python)

https://docs.python.org/2/library/os.html#os.makedirs

```
root@artillery-01:~/artillery# python ./artillery.py
Traceback (most recent call last):
  File "./artillery.py", line 70, in <module>
    os.mkdirs("/var/artillery/database/")
AttributeError: 'module' object has no attribute 'mkdirs'
```

After patching:
```
root@artillery-01:~/artillery# python ./artillery.py
[*] 2017-08-25 03:44:20: Artillery has started successfully.
[*] If on Windows Ctrl+C to exit.
[*] Console logging enabled.
```

