### PR TITLE
Resolves Issue #58

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -481,12 +481,12 @@ def write_log(alert):
 
 def warn_the_good_guys(subject, alert):
     email_alerts = is_config_enabled("EMAIL_ALERTS")
-    email_frequency = is_config_enabled("EMAIL_FREQUENCY")
+    email_timer = is_config_enabled("EMAIL_TIMER")
 
-    if email_alerts and not email_frequency:
+    if email_alerts and not email_timer:
         send_mail(subject, alert)
 
-    if email_alerts and email_frequency:
+    if email_alerts and email_timer:
         prep_email(alert + "\n")
 
     if is_config_enabled("CONSOLE_LOGGING"):


### PR DESCRIPTION
The proper configuration variable to test is EMAIL_TIMER.  is_config_enabled() only tests for OFF or ON, and it it's not ON it's OFF.  So the numerical value in the config variable EMAIL_FREQUENCY was setting the boolean to false, which caused the routine not immediately send the email rather than queuing it up.  

The other part of this fix is to actually create the /var/artillery/src/program_junk directory.  If it does not exists then the temporary email log file cannot be created and written to.