### PR TITLE
Space in SMTP_FROM value misinterpreted by postfix

### DIFF
--- a/config
+++ b/config
@@ -52,7 +52,7 @@ SMTP_PASSWORD=""
 ALERT_USER_EMAIL="user@whatever.com"
 #
 # FOR SMTP ONLY HERE, THIS IS THE MAILTO
-SMTP_FROM="Artillery Incident"
+SMTP_FROM="Artillery_Incident"
 #
 # SMTP ADDRESS FOR SENDING EMAILS, DEFAULT IS GMAIL
 SMTP_ADDRESS="smtp.gmail.com"


### PR DESCRIPTION
The current default value of "Artillery Incident" leads postfix to think that the email is actually from two addresses: Artillery@domain.com and Incident@domain.com.  This also leads spamassassin to trigger some FROM_ADDR_* rules.  I recommend at minimum replacing the space with an underscore.  Gmail may not have this issue.