### PR TITLE
url is incorrectly initialized as a string

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -661,7 +661,7 @@ def format_ips(url):
 def pull_source_feeds():
     while 1:
                 # pull source feeds
-        url = ""
+        url = []
         counter = 0
         # if we are using source feeds
         if read_config("SOURCE_FEEDS").lower() == "on":


### PR DESCRIPTION
There is a fail iff SOURCE_FEEDS is set to OFF and THREAT_INTELLIGENCE_FEED is set to ON in the config file.  Since url is initialized to a null string, instead of an empty array, the url.append(threats) statement on line 680 fails because a string does not have an append method.

There is also some variable renaming I would suggest in this area of the code:
1) the variable threat_feed should be renamed threat_feeds
2) the iterator threats should be renamed feed (for feed in threat_feeds:)