### PR TITLE
Only 1 line per email, wrong openfile mode

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -239,11 +239,11 @@ def prep_email(alert):
     if is_posix():
         # write the file out to program_junk
         filewrite = open(
-            "/var/artillery/src/program_junk/email_alerts.log", "w")
+            "/var/artillery/src/program_junk/email_alerts.log", "a")
     if is_windows():
         program_files = os.environ["PROGRAMFILES(X86)"]
         filewrite = open(
-            program_files + "\\Artillery\\src\\program_junk\\email_alerts.log", "w")
+            program_files + "\\Artillery\\src\\program_junk\\email_alerts.log", "a")
     filewrite.write(alert)
     filewrite.close()
 


### PR DESCRIPTION
The email_alerts.log file is being opened write (mode "w"), rather than append (mode "a") so no matter how many hits there were during the email period it would only send the last one because the file was overwritten every time.

Changed file mode for opening email_alerts.log to append 
