### PR TITLE
Add log messages as config variables

### DIFF
--- a/config
+++ b/config
@@ -124,6 +124,11 @@ ROOT_CHECK="ON"
 # Specify SYSLOG TYPE to be local, file or remote. LOCAL will pipe to syslog, REMOTE will pipe to remote SYSLOG, and file will send to alerts.log in local artillery directory
 SYSLOG_TYPE="LOCAL"
 #
+# LOG MESSAGES (IMPORTANT: Everything except the %s are optional.  e.g. a minimal message would be "%s %s %s" which would be
+# the time, the ipaddress, and the port number
+LOG_MESSAGE_ALERT="%s [!] Artillery has detected an attack from IP address: %s for a connection on a honeypot port: %s"
+LOG_MESSAGE_BAN="%s [!] Artillery has blocked (and blacklisted) the IP Address: %s for connecting to a honeypot restricted port: %s"
+#
 # IF YOU SPECIFY SYSLOG TYPE TO REMOTE, SPECIFY A REMOTE SYSLOG SERVER TO SEND ALERTS TO
 SYSLOG_REMOTE_HOST="192.168.0.1"
 #

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -25,6 +25,8 @@ udpports = read_config("UDPPORTS")
 bind_interface = read_config("BIND_INTERFACE")
 honeypot_ban = is_config_enabled("HONEYPOT_BAN")
 honeypot_autoaccept = is_config_enabled("HONEYPOT_AUTOACCEPT")
+log_message_ban = read_config("LOG_MESSAGE_BAN")
+log_message_alert = read_config("LOG_MESSAGE_ALERT")
 
 # main socket server listener for responses
 
@@ -55,10 +57,10 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                         now, ip)
                     alert = ""
                     if honeypot_ban:
-                        alert = "%s [!] Artillery has blocked (and blacklisted) the IP Address: %s for connecting to a honeypot restricted port: %s" % (
+                        alert = log_message_ban % (
                             now, ip, port)
                     else:
-                        alert = "%s [!] Artillery has detected an attack from IP address: %s for a connection on a honeypot port: %s" % (
+                        alert = log_message_alert % (
                             now, ip, port)
                     warn_the_good_guys(subject, alert)
 


### PR DESCRIPTION
The defaults are kind of verbose ;)

I didn't change the default messages, I just made it easy to change them.  I tried to be explicit that the 3 %s format specifiers are required but all the text is optional.  If you think I should actually test the string to make sure that there really are 3 %s in the strings when the service starts let me know and I'll add that.