### PR TITLE
add support for config setting HONEYPOT_BAN_LOG_PREFIX

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -117,6 +117,9 @@ def ban(ip):
                                 ip = convert_to_classc(ip)
                             subprocess.Popen(
                                 "iptables -I ARTILLERY 1 -s %s -j DROP" % ip, shell=True).wait()
+                        iptables_logprefix = read_config("HONEYPOT_BAN_LOG_PREFIX")
+                        if iptables_logprefix != "":
+                           subprocess.Popen("iptables -I ARTILLERY 1 -s %s -j LOG --log-prefix \"%s\"" % (ip, iptables_logprefix), shell=True).wait() 
                     # After the server is banned, add it to the banlist if it's
                     # not already in there
                     fileopen = open("/var/artillery/banlist.txt", "r")
@@ -351,6 +354,10 @@ def create_iptables_subset():
           ips_to_block = ','.join(iplist)
           massloadcmd = "iptables -I ARTILLERY -s %s -j DROP -w 3" % ips_to_block
           subprocess.Popen(massloadcmd, shell=True).wait()
+          iptables_prefix = read_config("HONEYPOT_BAN_LOG_PREFIX")
+          if iptables_prefix != "":
+             massloadcmd = "iptables -I ARTILLERY -s %s -j LOG --log-prefix \"%s\" -w 3" % (ips_to_block, iptables_prefix)
+             subprocess.Popen(massloadcmd, shell=True).wait() 
           total_added += len(iplist)
           write_log("[*] Artillery - %d/%d - Added %d/%d IP entries to iptables chain." % (listindex, len(iplists), total_added, total_nr))
           if logindex >= logthreshold:

--- a/src/core.py
+++ b/src/core.py
@@ -354,9 +354,9 @@ def create_iptables_subset():
           ips_to_block = ','.join(iplist)
           massloadcmd = "iptables -I ARTILLERY -s %s -j DROP -w 3" % ips_to_block
           subprocess.Popen(massloadcmd, shell=True).wait()
-          iptables_prefix = read_config("HONEYPOT_BAN_LOG_PREFIX")
-          if iptables_prefix != "":
-             massloadcmd = "iptables -I ARTILLERY -s %s -j LOG --log-prefix \"%s\" -w 3" % (ips_to_block, iptables_prefix)
+          iptables_logprefix = read_config("HONEYPOT_BAN_LOG_PREFIX")
+          if iptables_logprefix != "":
+             massloadcmd = "iptables -I ARTILLERY -s %s -j LOG --log-prefix \"%s\" -w 3" % (ips_to_block, iptables_logprefix)
              subprocess.Popen(massloadcmd, shell=True).wait() 
           total_added += len(iplist)
           write_log("[*] Artillery - %d/%d - Added %d/%d IP entries to iptables chain." % (listindex, len(iplists), total_added, total_nr))


### PR DESCRIPTION
Please add a new config variable HONEYPOT_BAN_LOG_PREFIX to the default config file (but leave it empty)
Whatever string is set to the variable, will be used as iptables log prefix

