### PR TITLE
remove need to host "config" file from github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 banlist.txt
+config

--- a/artillery.py
+++ b/artillery.py
@@ -38,6 +38,8 @@ if ('linux' or 'linux2' or 'darwin') in sys.platform:
 from src.core import *
 # from src.config import * # yaml breaks config reading - disabling
 
+check_config()
+
 if is_windows():#this is for launching script as admin from batchfile.
     if not isUserAdmin():# will prompt for user\pass and open in seperate window when you double click batchfile
         runAsAdmin()

--- a/artillery.py
+++ b/artillery.py
@@ -64,7 +64,7 @@ if is_windows():#this is for launching script as admin from batchfile.
         #will work on better way
         from src.events import ArtilleryStartEvent
         # let the local(txt))logfile know artillery has started successfully
-        write_log("[*] %s: Artillery has started successfully." % (grab_time()))
+        write_log("Artillery has started successfully.")
         # write to windows log to let know artillery has started
         ArtilleryStartEvent()
         #create temp datebase and continue
@@ -175,7 +175,7 @@ try:
 
     # let the program to continue to run
     write_console("All set.")
-    write_log("%s [*] Artillery is up and running" % grab_time())
+    write_log("Artillery is up and running")
     while 1:
         try:
             time.sleep(100000)
@@ -193,6 +193,6 @@ except KeyboardInterrupt:
 except Exception as e:
     emsg = traceback.format_exc()
     print("General exception: " + format(e) + "\n" + emsg)
-    write_log("%s [!] Error launching Artillery\n%s" % (grab_time(),emsg))
+    write_log("Error launching Artillery\n%s" % (emsg),2)
 
     sys.exit()

--- a/restart_server.py
+++ b/restart_server.py
@@ -15,7 +15,6 @@ kill_artillery()
 
 print("[*] %s: Restarting Artillery Server..." % (grab_time()))
 if os.path.isfile("/var/artillery/artillery.py"):
-    write_log("[*] %s: Restarting the Artillery Server process..." %
-              (grab_time()))
+    write_log("Restarting the Artillery Server process...",1)
     subprocess.Popen("python /var/artillery/artillery.py &",
                      stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)

--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,7 @@ if answer.lower() in ["yes", "y"]:
     else:
         choice = 'y'
     if choice in ["yes", "y"]:
+        check_config()
         if is_posix():
             # this cmd is what they were refering to as "no longer supported"? from update-rc.d on install.
             # It looks like service starts but you have to manually launch artillery

--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,8 @@
 
 import os
 import platform
+import globals
+
 if platform.system() == "Windows":
     import ntpath
 
@@ -18,14 +20,14 @@ def get_config_path():
     path = ""
     # ToDo: Support for command line argument pointing to config file.
     if is_posix():
-        if os.path.isfile("/var/artillery/config"):
-            path = "/var/artillery/config"
-        if os.path.isfile("config"):
-            path = "config"
+        if os.path.isfile(globals.g_configfile):
+            path = globals.g_configfile
+        #if os.path.isfile("config"):
+        #    path = "config"
     if is_windows():
         program_files = os.environ["ProgramFiles"]
-        if os.path.isfile(program_files + "\\Artillery\\config"):
-            path = program_files + "\\Artillery\\config"
+        if os.path.isfile(globals.g_configfile):
+            path = globals.g_configfile
     return path
 
 

--- a/src/core.py
+++ b/src/core.py
@@ -989,7 +989,7 @@ def format_ips(url):
     ips = ""
     for urls in url:
         try:
-            write_log("Grabbing feed from %s" % (str(urls)))
+            write_log("Grabbing feed from '%s'" % (str(urls)))
             urls = str(urls)
             f = []
             if urls.startswith("http"):
@@ -999,7 +999,7 @@ def format_ips(url):
                try:
                    f = open(urls,"r").readlines()
                except:
-                   write_log("Unable to read '%s'" % urls)
+                   write_log("Unable to read '%s'" % urls,2)
                    pass
             write_log("Retrieved %d lines from %s" % (len(f), str(urls)))
             for line in f:

--- a/src/core.py
+++ b/src/core.py
@@ -770,7 +770,8 @@ def syslog(message, alerttype):
         remote_port = int(read_config("SYSLOG_REMOTE_PORT"))
         syslogmsg = message
         if alertindicator != "":
-           syslogmsg = "%s %s Artillery: %s" % (grab_time(), alertindicator, message) 
+            syslogmsg = "Artillery%s: %s" % (alertindicator, message)
+           #syslogmsg = "%s %s Artillery: %s" % (grab_time(), alertindicator, message) 
         syslog_send(syslogmsg, host=remote_syslog, port=remote_port)
 
     # if we are sending local syslog messages
@@ -781,7 +782,8 @@ def syslog(message, alerttype):
         my_logger.addHandler(handler)
         for line in message.splitlines():
             if alertindicator != "":
-                my_logger.critical("%s %s Artillery: %s\n" % (grab_time(), alertindicator, line))
+                my_logger.critical("Artillery%s: %s\n" % (alertindicator, line))
+                #my_logger.critical("%s %s Artillery: %s\n" % (grab_time(), alertindicator, line))
             else:
                 my_logger.critical("%s\n" % line)
 
@@ -797,7 +799,7 @@ def syslog(message, alerttype):
             filewrite.close()
 
         filewrite = open("%s/logs/alerts.log" % globals.g_apppath, "a")
-        filewrite.write("%s %s Artillery: %s\n" % (grab_time(), alertindicator, message))
+        filewrite.write("Artillery%s: %s\n" % (alertindicator, message))
         filewrite.close()
 
 def write_console(alert):

--- a/src/core.py
+++ b/src/core.py
@@ -875,11 +875,8 @@ def warn_the_good_guys(subject, alert):
     if email_alerts and email_timer:
         prep_email(alert + "\n")
 
-    if is_config_enabled("CONSOLE_LOGGING"):
-        print("{}".format(alert))
-
     write_log(alert,1)
-
+    write_console(alert)
 # send the actual email
 
 

--- a/src/core.py
+++ b/src/core.py
@@ -134,7 +134,7 @@ def check_config():
     configdefaults["ARTILLERY_REFRESH"] = ["604800", "RECYCLE INTERVAL AFTER A CERTAIN AMOUNT OF MINUTES IT WILL OVERWRITE THE LOG WITH A BLANK ONE AND ELIMINATE THE IPS - DEFAULT IS 7 DAYS"]
     configdefaults["SOURCE_FEEDS"] = ["OFF", "PULL ADDITIONAL SOURCE FEEDS FOR BANNED IP LISTS FROM MULTIPLE OTHER SOURCES OTHER THAN ARTILLERY"] 
     configdefaults["LOCAL_BANLIST"] = ["OFF", "CREATE A SEPARATE LOCAL BANLIST FILE (USEFUL IF YOU'RE ALSO USING A THREAT FEED AND WANT TO HAVE A FILE THAT CONTAINS THE IPs THAT HAVE BEEN BANNED LOCALLY"]
-    configdefaults["THREAT_FILE"] = ["banlist.txt", "FILE TO COPY TO THREAT_LOCATION, TO ACT AS A THREAT_SERVER. CHANGE TO \"localbanlist.txt\" IF YOU HAVE ENABLED \"LOCAL_BANLIST\" AND WISH TO HOST YOUR LOCAL BANLIST"] 
+    configdefaults["THREAT_FILE"] = ["banlist.txt", "FILE TO COPY TO THREAT_LOCATION, TO ACT AS A THREAT_SERVER. CHANGE TO \"localbanlist.txt\" IF YOU HAVE ENABLED \"LOCAL_BANLIST\" AND WISH TO HOST YOUR LOCAL BANLIST. IF YOU WISH TO COPY BOTH FILES, SEPARATE THE FILES WITH A COMMA - f.i. \"banlist.txt,localbanlist.txt\""] 
 
     keyorder = []
     keyorder.append("MONITOR")
@@ -722,16 +722,17 @@ def printCIDR(attacker_ip):
 
 def threat_server():
     public_http = read_config("THREAT_LOCATION")
-    banfile = read_config("THREAT_FILE")
-    if banfile == "":
-        banfile = globals.g_banfile
-    else:
-        banfile = globals.g_apppath + "/" + banfile
     if os.path.isdir(public_http):
-        while 1:
-            subprocess.Popen("cp '%s' '%s'" %
-                             (banfile, public_http), shell=True).wait()
-            time.sleep(300)
+       banfiles = read_config("THREAT_FILE")
+       if banfiles == "":
+          banfiles = globals.g_banfile
+       banfileparts = banfiles.split(",")
+       while 1:
+          for banfile in banfileparts:
+             thisfile = globals.g_apppath + "/" + banfile
+             subprocess.Popen("cp '%s' '%s'" % (thisfile, public_http), shell=True).wait()
+             write_log("ThreatServer: Copy '%s' to '%s'" % (banfile, public_http))
+          time.sleep(300)
 
 # send the message then if its local or remote
 

--- a/src/core.py
+++ b/src/core.py
@@ -306,7 +306,7 @@ def execOScmd(cmd, logmsg=""):
     outputlines = []
     for l in outputobj:
         thisline = l.decode()
-        print(thisline)
+        #print(thisline)
         outputlines.append(thisline.replace('\\n','').replace("'",""))
     return outputlines
 

--- a/src/core.py
+++ b/src/core.py
@@ -200,7 +200,7 @@ def check_config():
        createnew = True
        #config file does not exist, determine new path
        if is_posix():
-          configpath = "config"
+          configpath = "/var/artillery/config"
        if is_windows():
           program_files = os.environ["PROGRAMFILES(X86)"]
           configpath = program_files + "\\Artillery\\config"

--- a/src/core.py
+++ b/src/core.py
@@ -753,7 +753,7 @@ def threat_server():
           for banfile in banfileparts:
              thisfile = globals.g_apppath + "/" + banfile
              subprocess.Popen("cp '%s' '%s'" % (thisfile, public_http), shell=True).wait()
-             write_log("ThreatServer: Copy '%s' to '%s'" % (thisfile, public_http))
+             #write_log("ThreatServer: Copy '%s' to '%s'" % (thisfile, public_http))
           time.sleep(300)
 
 # send the message then if its local or remote

--- a/src/core.py
+++ b/src/core.py
@@ -765,11 +765,11 @@ def syslog(message, alerttype):
     if alerttype == -1:
         alertindicator = ""
     elif alerttype == 0:
-        alertindicator = "[+]"
+        alertindicator = "[INFO]"
     elif alerttype == 1:
-        alertindicator = "[-]"
+        alertindicator = "[WARN]"
     elif alerttype == 2:
-        alertindicator = "[!!]"
+        alertindicator = "[ERROR]"
 
     # if we are sending remote syslog
     if type == "remote":

--- a/src/core.py
+++ b/src/core.py
@@ -526,6 +526,26 @@ def create_empty_file(filepath):
     filewrite.close()
 
 
+def write_banlist_banner(filepath):
+    filewrite = open(filepath, "w")
+    banner = """#
+#
+#
+# Binary Defense Systems Artillery Threat Intelligence Feed and Banlist Feed
+# https://www.binarydefense.com
+#
+# Note that this is for public use only.
+# The ATIF feed may not be used for commercial resale or in products that are charging fees for such services.
+# Use of these feeds for commerical (having others pay for a service) use is strictly prohibited.
+#
+#
+#
+"""
+    filewrite.write(banner)
+    filewrite.close()
+
+
+
 def create_iptables_subset():
     if is_posix():
         ban_check = read_config("HONEYPOT_BAN").lower()
@@ -542,11 +562,13 @@ def create_iptables_subset():
         banfile = open(check_banlist_path(), "r")
     else:
         create_empty_file(globals.g_banlist)
+        write_banlist_banner(globals.g_banlist)
         banfile = open(globals.g_banlist, "r")
 
     if read_config("LOCAL_BANLIST").lower() == "on":
         if not os.path.isfile(globals.g_localbanlist):
             create_empty_file(globals.g_localbanlist)
+            write_banlist_banner(globals.g_localbanlist)
     
     # if we are banning
     banlist = []
@@ -959,6 +981,7 @@ def refresh_log():
         time.sleep(interval)
         # overwrite the log with nothing
         create_empty_file(globals.g_banlist)
+        write_banlist_banner(globals.g_banlist)
 
 
 # format the ip addresses and check to ensure they aren't duplicates

--- a/src/core.py
+++ b/src/core.py
@@ -1013,10 +1013,9 @@ def format_ips(url):
                 # Error 404, page not found!
                 write_log(
                     "HTTPError: Error 404, URL {} not found.".format(urls))
-
             else:
-                write_log("Received URL Error, Reason: {}".format(err),1)
-                return
+                write_log("Received URL Error trying to download feed from '%s', Reason: %s" (urls, format(err)),1)
+                continue 
 
     try:
         if is_windows():

--- a/src/core.py
+++ b/src/core.py
@@ -991,7 +991,16 @@ def format_ips(url):
         try:
             write_log("Grabbing feed from %s" % (str(urls)))
             urls = str(urls)
-            f = urlopen(urls).readlines()
+            f = []
+            if urls.startswith("http"):
+               f = urlopen(urls).readlines()
+            else:
+               # try reading it as a file
+               try:
+                   f = open(urls,"r").readlines()
+               except:
+                   write_log("Unable to read '%s'" % urls)
+                   pass
             write_log("Retrieved %d lines from %s" % (len(f), str(urls)))
             for line in f:
                 line = line.rstrip()

--- a/src/core.py
+++ b/src/core.py
@@ -610,6 +610,7 @@ def create_iptables_subset():
 
     if len(banlist) > 0:
        # convert banlist into unique list
+       write_log("Filtering duplicate entries in banlist")
        set_banlist = set(banlist)
        unique_banlist = (list(set_banlist))
        entries_at_once = 750

--- a/src/core.py
+++ b/src/core.py
@@ -532,6 +532,9 @@ def create_iptables_subset():
                     if is_posix():
                        if not ip.startswith("0."):
                           if is_valid_ipv4(ip.strip()):
+                              if read_config("HONEYPOT_BAN_CLASSC").lower() == "on":
+                                 if not ip.endswith("/24"):
+                                    ip = convert_to_classc(ip)
                               banlist.append(ip)
                     if is_windows():
                        ban(ip)

--- a/src/core.py
+++ b/src/core.py
@@ -288,6 +288,12 @@ def ban(ip):
     ip = ip.rstrip()
     ban_check = read_config("HONEYPOT_BAN").lower()
     ban_classc = read_config("HONEYPOT_BAN_CLASSC").lower()
+    test_ip = ip
+    if "/" in test_ip:
+        test_ip = test_ip.split("/")[0]
+    if is_whitelisted_ip(test_ip):
+        write_log("Not banning IP %s, whitelisted" % test_ip)
+        return
     if ban_check == "on":
        if not ip.startswith("#"):
            if not ip.startswith("0."):
@@ -542,8 +548,6 @@ def create_iptables_subset():
         if not os.path.isfile(globals.g_localbanlist):
             create_empty_file(globals.g_localbanlist)
     
-    whitelist = read_config("WHITELIST_IP")
-
     # if we are banning
     banlist = []
     if read_config("HONEYPOT_BAN").lower() == "on":

--- a/src/core.py
+++ b/src/core.py
@@ -753,7 +753,7 @@ def threat_server():
           for banfile in banfileparts:
              thisfile = globals.g_apppath + "/" + banfile
              subprocess.Popen("cp '%s' '%s'" % (thisfile, public_http), shell=True).wait()
-             write_log("ThreatServer: Copy '%s' to '%s'" % (banfile, public_http))
+             write_log("ThreatServer: Copy '%s' to '%s'" % (thisfile, public_http))
           time.sleep(300)
 
 # send the message then if its local or remote

--- a/src/core.py
+++ b/src/core.py
@@ -125,8 +125,8 @@ def check_config():
     configdefaults["THREAT_LOCATION"] = ["/var/www/","PUBLIC LOCATION TO PULL VIA HTTP ON THE THREAT SERVER. NOTE THAT THREAT SERVER MUST BE SET TO ON"]
     configdefaults["ROOT_CHECK"] = ["ON", "THIS CHECKS TO SEE WHAT PERMISSIONS ARE RUNNING AS ROOT IN A WEB SERVER DIRECTORY"]
     configdefaults["SYSLOG_TYPE"] = ["LOCAL", "Specify SYSLOG TYPE to be local, file or remote. LOCAL will pipe to syslog, REMOTE will pipe to remote SYSLOG, and file will send to alerts.log in local artillery directory"]
-    configdefaults["LOG_MESSAGE_ALERT"] = ["%s [!] Artillery has detected an attack from IP address: %s for a connection on a honeypot port: %s", "ALERT LOG MESSAGES (IMPORTANT: Everything except the %s are optional.  e.g. a minimal message would be \"%s %s %s\" which would be time, ipaddress, port number"]
-    configdefaults["LOG_MESSAGE_BAN"] = ["%s [!] Artillery has blocked (and blacklisted) an attack from IP address: %s for a connection to a honeypot restricted port: %s", "BAN LOG MESSAGES (IMPORTANT: Everything except the %s are optional.  e.g. a minimal message would be \"%s %s %s\" which would be time, ipaddress, port number"]
+    configdefaults["LOG_MESSAGE_ALERT"] = ["Artillery has detected an attack from %ip% for a connection on a honeypot port %port%", "ALERT LOG MESSAGES (You can use the following variables: %time%, %ip%, %port%)"]
+    configdefaults["LOG_MESSAGE_BAN"] = ["Artillery has blocked (and blacklisted) an attack from %ip% for a connection to a honeypot restricted port %port%", "BAN LOG MESSAGES (You can use the following variables: %time%, %ip%, %port%)"]
     configdefaults["SYSLOG_REMOTE_HOST"] = ["192.168.0.1","IF YOU SPECIFY SYSLOG TYPE TO REMOTE, SPECIFY A REMOTE SYSLOG SERVER TO SEND ALERTS TO"]
     configdefaults["SYSLOG_REMOTE_PORT"] = ["514", "IF YOU SPECIFY SYSLOG TYPE OF REMOTE, SEPCIFY A REMOTE SYSLOG PORT TO SEND ALERTS TO"]
     configdefaults["CONSOLE_LOGGING"] = ["ON", "TURN ON CONSOLE LOGGING"]
@@ -878,7 +878,7 @@ def warn_the_good_guys(subject, alert):
     if is_config_enabled("CONSOLE_LOGGING"):
         print("{}".format(alert))
 
-    write_log(alert,-1)
+    write_log(alert,1)
 
 # send the actual email
 

--- a/src/ftp_monitor.py
+++ b/src/ftp_monitor.py
@@ -20,6 +20,7 @@ monitor_time = int(monitor_time)
 ftp_attempts = read_config("FTP_BRUTE_ATTEMPTS")
 # check for whitelist
 
+import globals
 
 def ftp_monitor(monitor_time):
     while 1:
@@ -30,9 +31,9 @@ def ftp_monitor(monitor_time):
             print("Has not found configuration file for ftp. Ftp monitor now stops.")
             break
 
-        if not os.path.isfile("/var/artillery/banlist.txt"):
+        if not os.path.isfile(globals.g_banlist):
             # create a blank file
-            filewrite = file("/var/artillery/banlist.txt", "w")
+            filewrite = file(globals.g_banlist, "w")
             filewrite.write("")
             filewrite.close()
 
@@ -42,7 +43,7 @@ def ftp_monitor(monitor_time):
             counter = 0
             for line in fileopen1:
                 counter = 0
-                fileopen2 = file("/var/artillery/banlist.txt", "r")
+                fileopen2 = file(globals.g_banlist, "r")
                 line = line.rstrip()
                 # search for bad ftp
                 match = re.search("CONNECT: Client", line)

--- a/src/globals.py
+++ b/src/globals.py
@@ -1,0 +1,6 @@
+# Artillery - globals
+
+global g_apppath
+global g_configfile
+global g_banlist
+global g_localbanlist

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -81,7 +81,10 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                     warn_the_good_guys(subject, alert)
 
                     # close the socket
-                    self.request.close()
+                    try:
+                       self.request.close()
+                    except:
+                        pass
 
                     # if it isn't whitelisted and we are set to ban
                     ban(ip)

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -67,8 +67,8 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                     message = message.replace("%time%", now)
                     message = message.replace("%ip%", ip)
                     message = message.replace("%port%", port)
+                    alert = message
                     if "%" in message:
-                        alert = message
                         nrvars = message.count("%")
                         if nrvars  == 1:
                             alert = message % (now)
@@ -76,8 +76,6 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                             alert = message % (now, ip)
                         elif nrvars == 3:
                             alert = message % (now, ip, port)
-                    else:
-                        alert = message
 
                     warn_the_good_guys(subject, alert)
 

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -187,14 +187,18 @@ def main(tcpports, udpports, bind_interface):
     # split into tuple
     tports = tcpports.split(",")
     for tport in tports:
-        write_log("Set up listener for tcp port %s" % tport)
-        thread.start_new_thread(listentcp_server, (tport, bind_interface,))
+        tport = tport.replace(" ","")
+        if tport != "":
+           write_log("Set up listener for tcp port %s" % tport)
+           thread.start_new_thread(listentcp_server, (tport, bind_interface,))
 
     # split into tuple
     uports = udpports.split(",")
     for uport in uports:
-        write_log("Set up listener for udp port %s" % uport)
-        thread.start_new_thread(listenudp_server, (uport, bind_interface,))
+        uport = uport.replace(" ","")
+        if uport != "":
+           write_log("Set up listener for udp port %s" % uport)
+           thread.start_new_thread(listenudp_server, (uport, bind_interface,))
 
 # launch the application
 main(tcpports, udpports, bind_interface)

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -100,13 +100,13 @@ def listentcp_server(tcpport, bind_interface):
             if ban_check == "on":
                 subprocess.Popen(
                     "iptables -A ARTILLERY -p tcp --dport %s  -j ACCEPT -w 3" % port, shell=True).wait()
-                write_log("[*] Artillery - Created iptables rule to accept incoming traffic to tcp %s" % port)
+                write_log("Created iptables rule to accept incoming traffic to tcp %s" % port)
         server.serve_forever()
     # if theres already something listening on this port
     except Exception:
         # write a log if we are unable to bind to an interface
-        write_log("[!] %s: Artillery was unable to bind to TCP port: %s. This could be to an active port in use." % (
-            grab_time(), port))
+        write_log("Artillery was unable to bind to TCP port: %s. This could be to an active port in use." % (
+            port),2)
         errormsg = socket.gethostname() + " | %s | Artillery error - unable to bind to TCP port %s" % (grab_time(), port)
         send_mail(errormsg, errormsg)
         pass
@@ -126,13 +126,13 @@ def listenudp_server(udpport, bind_interface):
             if ban_check == "on":
                 subprocess.Popen(
                     "iptables -A ARTILLERY -p udp --dport %s  -j ACCEPT -w 3" % port, shell=True).wait()
-                write_log("[*] Artillery - Created iptables rule to accept incoming traffic to udp %s" % port)
+                write_log("Created iptables rule to accept incoming traffic to udp %s" % port)
         server.serve_forever()
       # if theres already something listening on this port
       except Exception:
         # write a log if we are unable to bind to an interface
-        write_log("[!] %s: Artillery was unable to bind to UDP port: %s. This could be to an active port in use." % (
-            grab_time(), port))
+        write_log("Artillery was unable to bind to UDP port: %s. This could be to an active port in use." % (
+            port),2)
         errormsg = socket.gethostname() + " | %s | Artillery error - unable to bind to UDP port %s" % (grab_time(), port)
         send_mail(errormsg, errormsg)
         pass

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -61,18 +61,23 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                     subject = "%s [!] Artillery has detected an attack from the IP Address: %s" % (
                         now, ip)
                     alert = ""
+                    message = log_message_alert
                     if honeypot_ban:
-                        log_message_ban = log_message_ban.replace("%time%", now)
-                        log_message_ban = log_message_ban.replace("%ip%", ip)
-                        log_message_ban = log_message_ban.replace("%port%", port)
-                        if "%" in log_message_ban:
-                           alert = log_message_ban % (now, ip, port)
+                        message = log_message_ban
+                    message = message.replace("%time%", now)
+                    message = message.replace("%ip%", ip)
+                    message = message.replace("%port%", port)
+                    if "%" in message:
+                        alert = message
+                        nrvars = message.count("%")
+                        if nrvars  == 1:
+                            alert = message % (now)
+                        elif nrvars == 2:
+                            alert = message % (now, ip)
+                        elif nrvars == 3:
+                            alert = message % (now, ip, port)
                     else:
-                        log_message_alert = log_message_alert.replace("%time%", now)
-                        log_message_alert = log_message_alert.replace("%ip%", ip)
-                        log_message_alert = log_message_alert.replace("%port%", port)
-                        if "%" in log_message_alert:
-                            alert = log_message_alert % (now, ip, port)
+                        alert = message
 
                     warn_the_good_guys(subject, alert)
 
@@ -81,6 +86,8 @@ class SocketListener((SocketServer.BaseRequestHandler)):
 
                     # if it isn't whitelisted and we are set to ban
                     ban(ip)
+                else:
+                    write_log("Ignore connection from %s to port %s, whitelisted" % (ip, self.server.server_address[1]))
 
         except Exception as e:
             emsg = traceback.format_exc()

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -49,6 +49,7 @@ class SocketListener((SocketServer.BaseRequestHandler)):
         try:
             ip = self.client_address[0]
             try:
+                write_log("Honeypot detected incoming connection from %s to port %s" % (ip, self.server.server_address[0]))
                 self.request.send(fake_string)
             except Exception as e:
                 print("[!] Unable to send data to %s:%s" % (ip, self.server.server_address[1]))
@@ -149,28 +150,8 @@ def listenudp_server(udpport, bind_interface):
         send_mail(errormsg, errormsg)
         pass
 
-# check to see which ports we are using and ban if ports are touched
-
 
 def main(tcpports, udpports, bind_interface):
-    # pull the banlist path
-    # consider removing, will handle whitelisted IPs somewhere else
-    #if os.path.isfile("check_banlist_path"):
-    #    banlist_path = globals.g_banlist
-    #    fileopen = file(banlist_path, "r")
-    #    for line in fileopen:
-    #        # remove any bogus characters
-    #        line = line.rstrip()
-    #        # ban actual IP addresses
-    #        if honeypot_ban:
-    #            whitelist = read_config("WHITELIST_IP")
-    #            match = re.search(line, whitelist)
-    #            if not match:
-    #                # ban the ipaddress
-    #                ban(line)
-    #            else:
-    #                if line != "":
-    #                   write_log("Not banning %s, whitelisted" % line)
 
     # split into tuple
     tports = tcpports.split(",")

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -141,21 +141,25 @@ def listenudp_server(udpport, bind_interface):
 
 
 def main(tcpports, udpports, bind_interface):
+    # pull the banlist path
+    # consider removing, will handle whitelisted IPs somewhere else
+    #if os.path.isfile("check_banlist_path"):
+    #    banlist_path = globals.g_banlist
+    #    fileopen = file(banlist_path, "r")
+    #    for line in fileopen:
+    #        # remove any bogus characters
+    #        line = line.rstrip()
+    #        # ban actual IP addresses
+    #        if honeypot_ban:
+    #            whitelist = read_config("WHITELIST_IP")
+    #            match = re.search(line, whitelist)
+    #            if not match:
+    #                # ban the ipaddress
+    #                ban(line)
+    #            else:
+    #                if line != "":
+    #                   write_log("Not banning %s, whitelisted" % line)
 
-        # pull the banlist path
-    if os.path.isfile("check_banlist_path"):
-        banlist_path = check_banlist_path()
-        fileopen = file(banlist_path, "r")
-        for line in fileopen:
-            # remove any bogus characters
-            line = line.rstrip()
-            # ban actual IP addresses
-            if honeypot_ban:
-                whitelist = read_config("WHITELIST_IP")
-                match = re.search(line, whitelist)
-                if not match:
-                        # ban the ipaddress
-                    ban(line)
     # split into tuple
     tports = tcpports.split(",")
     for tport in tports:

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -49,7 +49,7 @@ class SocketListener((SocketServer.BaseRequestHandler)):
         try:
             ip = self.client_address[0]
             try:
-                write_log("Honeypot detected incoming connection from %s to port %s" % (ip, self.server.server_address[0]))
+                write_log("Honeypot detected incoming connection from %s to port %s" % (ip, self.server.server_address[1]))
                 self.request.send(fake_string)
             except Exception as e:
                 print("[!] Unable to send data to %s:%s" % (ip, self.server.server_address[1]))

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -62,11 +62,18 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                         now, ip)
                     alert = ""
                     if honeypot_ban:
-                        alert = log_message_ban % (
-                            now, ip, port)
+                        log_message_ban = log_message_ban.replace("%time%", now)
+                        log_message_ban = log_message_ban.replace("%ip%", ip)
+                        log_message_ban = log_message_ban.replace("%port%", port)
+                        if "%" in log_message_ban:
+                           alert = log_message_ban % (now, ip, port)
                     else:
-                        alert = log_message_alert % (
-                            now, ip, port)
+                        log_message_alert = log_message_alert.replace("%time%", now)
+                        log_message_alert = log_message_alert.replace("%ip%", ip)
+                        log_message_alert = log_message_alert.replace("%port%", port)
+                        if "%" in log_message_alert:
+                            alert = log_message_alert % (now, ip, port)
+
                     warn_the_good_guys(subject, alert)
 
                     # close the socket

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -52,13 +52,13 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                 write_log("Honeypot detected incoming connection from %s to port %s" % (ip, self.server.server_address[1]))
                 self.request.send(fake_string)
             except Exception as e:
-                print("[!] Unable to send data to %s:%s" % (ip, self.server.server_address[1]))
+                write_console("Unable to send data to %s:%s" % (ip, str(self.server.server_address[1])))
                 pass
             if is_valid_ipv4(ip):
                 # ban the mofos
                 if not is_whitelisted_ip(ip):
                     now = str(datetime.datetime.today())
-                    port = self.server.server_address[1]
+                    port = str(self.server.server_address[1])
                     subject = "%s [!] Artillery has detected an attack from the IP Address: %s" % (
                         now, ip)
                     alert = ""
@@ -67,7 +67,7 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                         message = log_message_ban
                     message = message.replace("%time%", now)
                     message = message.replace("%ip%", ip)
-                    message = message.replace("%port%", port)
+                    message = message.replace("%port%", str(port))
                     alert = message
                     if "%" in message:
                         nrvars = message.count("%")
@@ -76,7 +76,7 @@ class SocketListener((SocketServer.BaseRequestHandler)):
                         elif nrvars == 2:
                             alert = message % (now, ip)
                         elif nrvars == 3:
-                            alert = message % (now, ip, port)
+                            alert = message % (now, ip, str(port))
 
                     warn_the_good_guys(subject, alert)
 
@@ -92,6 +92,7 @@ class SocketListener((SocketServer.BaseRequestHandler)):
             emsg = traceback.format_exc()
             print("[!] Error detected. Printing: " + str(e))
             print(emsg)
+            write_log(emsg,2)
             print("")
             pass
 

--- a/src/honeypot.py
+++ b/src/honeypot.py
@@ -47,8 +47,12 @@ class SocketListener((SocketServer.BaseRequestHandler)):
 
         # try the actual sending and banning
         try:
-            self.request.send(fake_string)
             ip = self.client_address[0]
+            try:
+                self.request.send(fake_string)
+            except Exception as e:
+                print("[!] Unable to send data to %s:%s" % (ip, self.server.server_address[1]))
+                pass
             if is_valid_ipv4(ip):
                 # ban the mofos
                 if not is_whitelisted_ip(ip):

--- a/src/ssh_monitor.py
+++ b/src/ssh_monitor.py
@@ -9,6 +9,8 @@ try: import thread
 except ImportError: import _thread as thread
 from src.core import *
 
+import globals
+
 monitor_frequency = int(read_config("MONITOR_FREQUENCY"))
 ssh_attempts = read_config("SSH_BRUTE_ATTEMPTS")
 
@@ -39,9 +41,9 @@ def ssh_monitor(monitor_frequency):
                 fileopen1 = open("/var/log/faillog", "r")
                 counter = 1
 
-        if not os.path.isfile("/var/artillery/banlist.txt"):
+        if not os.path.isfile(globals.g_banlist):
             # create a blank file
-            filewrite = open("/var/artillery/banlist.txt", "w")
+            filewrite = open(globals.g_banlist, "w")
             filewrite.write("")
             filewrite.close()
 
@@ -51,7 +53,7 @@ def ssh_monitor(monitor_frequency):
             counter = 0
             for line in fileopen1:
                 counter = 0
-                fileopen2 = open("/var/artillery/banlist.txt", "r")
+                fileopen2 = open(globals.g_banlist, "r")
                 line = line.rstrip()
                 # search for bad ssh
                 match = re.search("Failed password for", line)


### PR DESCRIPTION
with this update, the config file will be created by artillery. That means we can remove the default template "config" file from github.  This way, we can avoid merge conflicts when "git pull" is used to keep artillery updated.

Impact to dev:
When there is a need to add a new configuration parameter, or to change a default value, simply edit core.py, look for `check_config` and add the desired new parameter (and its default value), and all config files will automatically get the new configuration parameter after the next "git pull" update, without affecting the already existing config settings.

When this PR has been merged, you should be able to remove the default config file (and added to .gitignore).  Existing config settings will be preserved by the script.... however, what still needs to be tested is to check/see if the existing config file is preserved (not deleted from installed systems) when people run "git pull". 
(I am assuming that adding "config" to .gitignore will take care of that... but I'm not sure)


